### PR TITLE
Remove deprecated CONSTANT from v1 code for php5.6

### DIFF
--- a/Base.php
+++ b/Base.php
@@ -555,7 +555,6 @@ class Base extends CoreBase
 
     protected static $setIntegerKeys = array(
         'BufferSize' => CURLOPT_BUFFERSIZE,
-        'ClosePolicy' => CURLOPT_CLOSEPOLICY,
         'ConnectTimeout' => CURLOPT_CONNECTTIMEOUT,
         'ConnectTimeoutMs' => CURLOPT_CONNECTTIMEOUT_MS,
         'DnsCacheTimeout' => CURLOPT_DNS_CACHE_TIMEOUT,


### PR DESCRIPTION
php5.6+ gives warnings with this constant when the Curl module is used.

Please create a `v1` branch and merge this and tag as 1.0.5

i just cherry-picked the commit used on the v4 branch
